### PR TITLE
Update xfinity.ts

### DIFF
--- a/src/xfinity.ts
+++ b/src/xfinity.ts
@@ -145,6 +145,7 @@ export class Xfinity extends EventEmitter {
         await page.click('#sign_in');
         await page.waitForNavigation({ waitUntil: 'networkidle2' });
 
+        await page.waitForSelector('title');
         const pageTitle = await page.title();
         console.log('Page Title: ', pageTitle);
         if (pageTitle === SECURITY_CHECK_TITLE) {


### PR DESCRIPTION
The page title is slow to load which results in puppeteer's error "Browser Error: Error: Execution context was destroyed, most likely because of a navigation". Waiting for the title to load fixes this error.