### PR TITLE
Maintain Xfinity account session (less password resets)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -15,7 +15,7 @@ export let usage: xfinityUsage | undefined;
 let config: Config;
 try {
     config = new Config();
-} catch (e) {
+} catch (e: any) {
     console.log(e.message);
     process.exit(1);
 }

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -1,0 +1,24 @@
+import { readFileSync, writeFile } from 'fs';
+import puppeteer from 'puppeteer-core';
+
+const COOKIES_FILE = '/config/cookies.json';
+
+export default class Cookies {
+    readCookies(): Array<puppeteer.Protocol.Network.CookieParam> {
+        try {
+            const data = readFileSync(COOKIES_FILE, 'utf-8');
+            return JSON.parse(data);
+        } catch (e: any) {
+            console.log('Unable to load cookies file.');
+            return [];
+        }
+    }
+
+    async writeCookies(cookies: Array<puppeteer.Protocol.Network.CookieParam>): Promise<void> {
+        return writeFile(COOKIES_FILE, JSON.stringify(cookies), (error) => {
+            if (error) {
+                console.error('Unable to write cookies files.', error);
+            }
+        });
+    }
+}

--- a/src/fetch-usage.ts
+++ b/src/fetch-usage.ts
@@ -16,7 +16,7 @@ process.on('message', async (msg: processMessage) => {
             const xfinity = new Xfinity(msg.xfinityConfig as xfinityConfig, msg.imapConfig as imapConfig);
             const data = await xfinity.fetch();
             send({ type: 'usage', usage: data });
-        } catch (e) {
+        } catch (e: any) {
             send({ type: 'error', message: e.message });
         } finally {
             exit();

--- a/src/mqtt.ts
+++ b/src/mqtt.ts
@@ -104,7 +104,7 @@ export class mqtt {
 
         try {
             await this.#client.publish(topic, JSON.stringify(data), options);
-        } catch (e) {
+        } catch (e: any) {
             console.log(topic, e.stack);
         }
     }


### PR DESCRIPTION
I've been getting tons of Xfinity password resets and I've made an enhancement that will cut down on it.

Instead of logging in every single time, this PR will persist the cookies that contain the session information to the filesystem. The cookies will be reused on every fetch, and if the fetch occurred recently, the session will be maintained, avoiding a login.

If for some reason the session does expire, the fetch will login in again and follow the exact same logic for passwords resets as before.

In addition to this cookies, I made a small change for compliance with TypeScript 4.4: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#using-unknown-in-catch-variables