### PR TITLE
feat: Configurable config folder

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,8 @@ import logger from './logger.js';
 import { mqttConfig } from './mqtt.js';
 import { xfinityConfig } from './xfinity.js';
 
+const CONFIG_FOLDER = process.env.CONFIG_FOLDER ?? '/config';
+
 interface config {
     xfinity: xfinityConfig;
     http?: null;
@@ -48,7 +50,7 @@ export class Config {
     loadConfig(): config {
         let config: config;
         try {
-            config = yaml.load(fs.readFileSync('/config/config.yml', 'utf8')) as config;
+            config = yaml.load(fs.readFileSync(CONFIG_FOLDER + '/config.yml', 'utf8')) as config;
         } catch (e) {
             throw new Error('Config file not found.');
         }

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -3,7 +3,8 @@ import puppeteer from 'puppeteer-core';
 
 import logger from './logger.js';
 
-const COOKIES_FILE = '/config/cookies.json';
+const CONFIG_FOLDER = process.env.CONFIG_FOLDER ?? '/config';
+const COOKIES_FILE = CONFIG_FOLDER + '/cookies.json';
 
 export default class Cookies {
     readCookies(): Array<puppeteer.Protocol.Network.CookieParam> {

--- a/src/password.ts
+++ b/src/password.ts
@@ -2,7 +2,8 @@ import { readFileSync, writeFile } from 'fs';
 
 import logger from './logger.js';
 
-const SUFFIX_FILE = '/config/pwsuffix';
+const CONFIG_FOLDER = process.env.CONFIG_FOLDER ?? '/config';
+const SUFFIX_FILE = CONFIG_FOLDER + '/pwsuffix';
 
 export default class Password {
     private password: string;


### PR DESCRIPTION
This PR adds a new environment variable `CONFIG_FOLDER` that allows the config folder's location to be changed from the default `/config`.

### Why make the config folder location modifiable?

I'm working on writing a small shim to make this a Home Assistant Add-on. The current config folder's location conflicts with Home Assistant's when mapped into the container. My goal is to allow the add-on to use a folder within Home Assistant's `/config`, i.e. setting `CONFIG_FOLDER=/config/xfinity-data-usage`.