### PR TITLE
Add Helm Chart for Kubernetes Deployment

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+name: xfinity-data-usage
+version: 1.0.0
+description: Fetch Xfinity data usage and serve it via an HTTP endpoint, publish it to MQTT or post it to an URL.
+keywords:
+ - xfinity
+ - homeassistant
+home: https://github.com/zachowj/xfinity-data-usage
+sources:
+ - https://github.com/zachowj/xfinity-data-usage

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,0 +1,96 @@
+# Helm Chart for Xfinity Data Usage
+
+Fetch Xfinity data usage and serve it via an HTTP endpoint, publish it to MQTT
+or post it to an URL.
+
+To learn more, visit <https://github.com/zachowj/xfinity-data-usage>.
+
+## Prerequisites
+
+- Kubernetes 1.10+
+
+## Installing the Chart
+
+```console
+git clone https://github.com/zachowj/xfinity-data-usage.git
+helm install \
+  --set config.xfinity.username=USERNAME_HERE \
+  --set config.xfinity.password=PASSWORD_HERE \
+  xfinity-data-usage xfinity-data-usage/chart
+```
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall the `xfinity-data-usage` release:
+
+```console
+helm uninstall xfinity-data-usage
+```
+
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.
+
+## Configuration parameters
+
+The following table lists the configurable parameters of the Xfinity Data Usage
+chart and their default values.
+
+| Parameter                          | Description                                                                                                 | Default                                  |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `config.xfinity.username`          | Username for Xfinity.                                                                                       | `""`                                     |
+| `config.xfinity.password`          | Password for Xfinity.                                                                                       | `""`                                     |
+| `config.xfinity.interval`          | Interval at which to update usage data (in minutes).                                                        | `60`                                     |
+| `config.xfinity.pageTimeout`       | Number of seconds until request times out (in seconds).                                                     | `30`                                     |
+| `config.http`                      | Enable HTTP endpoints for most recent data.                                                                 | `true`                                   |
+| `config.post.url`                  | URL where to post usage data to.                                                                            | `unset`                                  |
+| `config.mqtt.host`                 | Address of MQTT server.                                                                                     | `unset`                                  |
+| `config.mqtt.port`                 | Port of MQTT server.                                                                                        | `unset`                                  |
+| `config.mqtt.username`             | Username for MQTT server.                                                                                   | `unset`                                  |
+| `config.mqtt.password`             | Password for MQTT server.                                                                                   | `unset`                                  |
+| `config.mqtt.topic`                | Topic to publish usage data to if Home Assistant is not set.                                                | `unset`                                  |
+| `config.mqtt.homeassistant.prefix` | Auto discovery prefix topic.                                                                                | `unset`                                  |
+| `replicaCount`                     | Number of pod replicas. Only one replica is currently supported.                                            | `1`                                      |
+| `image.repository`                 | Repository of the container image.                                                                          | `docker.io/zachowj/xfinity-data-usage`   |
+| `image.tag`                        | Tag of the container image.                                                                                 | `latest`                                 |
+| `image.pullPolicy`                 | Container image pull policy.                                                                                | `Always`                                 |
+| `image.imagePullSecrets`           | Name of image pull secrets to be used by kubernetes.                                                        | `[]`                                     |
+| `nameOverride`                     | Overrides the name of the chart.                                                                            | `""`                                     |
+| `fullnameOverride`                 | Overrides the full name of the chart.                                                                       | `""`                                     |
+| `service.type`                     | Service type.                                                                                               | `NodePort`                               |
+| `service.port`                     | Incoming port to access Xfinity Data Usage.                                                                 | `7878`                                   |
+| `ingress.enabled`                  | Enable ingress.                                                                                             | `true`                                   |
+| `ingress.className`                | Ingress className.                                                                                          | `""`                                     |
+| `ingress.annotations`              | Ingress annotations.                                                                                        | `{}`                                     |
+| `ingress.hosts`                    | Ingress hosts.                                                                                              | `[]`                                     |
+| `ingress.tls`                      | Ingress TLS configuration.                                                                                  | `[]`                                     |
+| `resources`                        | CPU/memory resource requests/limits.                                                                        | `{}`                                     |
+| `nodeSelector`                     | Node labels for pod assignment.                                                                             | `{}`                                     |
+| `tolerations`                      | Toleration labels for pod assignment.                                                                       | `[]`                                     |
+| `affinity`                         | Affinity settings for pod assignment.                                                                       | `{}`                                     |
+| `podSecurityContext`               | Set SecurityContext on the pod level.                                                                       | `{}`                                     |
+| `podAnnotations`                   | Set annotations on the pod level.                                                                           | `{}`                                     |
+| `podLabels`                        | Set labels on the pod level.                                                                                | `{}`                                     |
+| `securityContext`                  | Set the securityContext for the pod.                                                                        | `{}`                                     |
+| `volumes`                          | Additional volumes available to containers.                                                                 | `[]`                                     |
+| `volumeMounts`                     | Additional mount points of volumes in a container.                                                          | `[]`                                     |
+
+Specify each parameter using the `--set key=value` argument to `helm install`.
+For example,
+
+```console
+helm install \
+  --set config.xfinity.username=USERNAME_HERE \
+  --set config.xfinity.password=PASSWORD_HERE \
+  xfinity-data-usage xfinity-data-usage/chart
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be
+provided while installing the chart. For example,
+
+```console
+helm install -f values.yaml xfinity-data-usage xfinity-data-usage/chart
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,24 @@
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+1. Get the application URL by running these commands:
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "xfinity-data-usage.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+1. Get the application URL by running these commands:
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "xfinity-data-usage.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "xfinity-data-usage.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+1. Get the application URL by running these commands:
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "xfinity-data-usage.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "xfinity-data-usage.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "xfinity-data-usage.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "xfinity-data-usage.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "xfinity-data-usage.labels" -}}
+helm.sh/chart: {{ include "xfinity-data-usage.chart" . }}
+{{ include "xfinity-data-usage.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "xfinity-data-usage.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "xfinity-data-usage.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "xfinity-data-usage.fullname" . }}-config
+  labels:
+    {{- include "xfinity-data-usage.labels" . | nindent 4 }}
+data:
+  config.yml: |
+    {{- toYaml .Values.config | nindent 4 }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "xfinity-data-usage.fullname" . }}
+  labels:
+    {{- include "xfinity-data-usage.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "xfinity-data-usage.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "xfinity-data-usage.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          - name: config-volume
+            mountPath: /config
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+      - name: config-volume
+        configMap:
+          name: {{ include "xfinity-data-usage.fullname" . }}-config
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "xfinity-data-usage.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "xfinity-data-usage.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "xfinity-data-usage.fullname" . }}
+  labels:
+    {{- include "xfinity-data-usage.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "xfinity-data-usage.selectorLabels" . | nindent 4 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,62 @@
+config:
+  xfinity:
+    username: ""
+    password: ""
+    interval: 60
+    pageTimeout: 30
+  http: true
+  # post:
+  #   url: http://localhost:1880/xfinity
+  # mqtt:
+  #   host: localhost
+  #   port: 1883
+  #   username: USERNAME
+  #   password: PASSWORD
+  #   topic: xfinity
+  #   homeassistant:
+  #     prefix: "homeassistant"
+
+replicaCount: 1
+
+image:
+  repository: docker.io/zachowj/xfinity-data-usage
+  pullPolicy: Always
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: NodePort
+  port: 7878
+
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  hosts:
+    - host: xfinity-data-usage.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+podSecurityContext: {}
+
+podAnnotations: {}
+podLabels: {}
+
+securityContext: {}
+
+volumes: []
+
+volumeMounts: []


### PR DESCRIPTION
Adds a [Helm chart](https://helm.sh) for easy deployment, maintenance, and updates of `xfinity-data-usage` when running on Kubernetes.

I've been running this for a bit on Kubernetes via Helm and figured I would clean it up and see if it could be added to the project.

Let me know if there are any particular improvements that need to be made for acceptance. Thanks!